### PR TITLE
Remove duplicate workflow_dispatch declaration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,6 @@ on:
   # Allows deployment to be invoked manually through the GitHub Actions user interface.
   #
   workflow_dispatch: 
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
   
 jobs:
   build:


### PR DESCRIPTION
Duplicate declaration of `workflow_dispatch` is breaking the CI pipeline.
Older comment kept because it fits the style of other comments.

Note: I also needed to run `npm install` to update some packages. I don't know much about node.js, or conventions around it. so I did not include a commit to update them!

Excellent book, I'm learning quite a bit!